### PR TITLE
workflow: took off running the workflow with direct push

### DIFF
--- a/.github/workflows/deployement_pipeline.yml
+++ b/.github/workflows/deployement_pipeline.yml
@@ -1,10 +1,6 @@
 name: Deployment pipeline
 
 on:
-  push:
-    branches:
-      - master
-      - part11-20
   pull_request:
     branches: [master]
     types: [opened, synchronize]


### PR DESCRIPTION
Took of running the workflow on direct push, because only pull request merges should now be allowed to master.